### PR TITLE
Fix header order and add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "generateReport.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "keywords": [],
   "author": "",
@@ -12,5 +12,9 @@
   "type": "commonjs",
   "dependencies": {
     "exceljs": "^4.4.0"
+  },
+  "devDependencies": {
+    "chai": "^5.2.1",
+    "mocha": "^11.7.1"
   }
 }

--- a/test/headerSort.test.js
+++ b/test/headerSort.test.js
@@ -1,0 +1,19 @@
+const { expect } = require('chai');
+const { parseMetadata } = require('../generateReport');
+
+describe('Employee Survey header sorting', () => {
+  it('should maintain column order from metadata', () => {
+    const meta = parseMetadata('Employee Survey');
+    const dataFields = meta.entries
+      .filter(e => (e['Is Header'] || '').toUpperCase() !== 'Y')
+      .map(e => e['Field Name']);
+    expect(dataFields).to.eql([
+      'Record',
+      'Title',
+      'Sex',
+      'Classification',
+      'Supervisor',
+      'Eval Number'
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure Excel columns keep metadata order and sanitize string data
- always wrap header text and escape quotes when writing workbook
- export functions from `generateReport.js` for testing
- add Mocha/Chai and test header sorting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68778291f6708327970ef07022c50331