### PR TITLE
Add PDF output support

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "type": "commonjs",
   "dependencies": {
     "csv-parse": "^6.0.0",
-    "exceljs": "^4.4.0"
+    "exceljs": "^4.4.0",
+    "pdfkit": "^0.17.1"
   },
   "devDependencies": {
     "chai": "^5.2.1",


### PR DESCRIPTION
## Summary
- parse Output Target and Heading Type from metadata
- support grouping with page breaks when Heading Type is `Page`
- add PDF rendering using pdfkit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877d67b483083278772b9ba20e0360e